### PR TITLE
Remove duplicate minSdkVersion

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -19,7 +19,7 @@
           android:versionCode="1"
           android:versionName="1.0">
 
-    <uses-sdk android:minSdkVersion="19"/>
+ 
     <uses-sdk
         android:minSdkVersion="11"
         android:targetSdkVersion="19"/>


### PR DESCRIPTION
Remove    <uses-sdk android:minSdkVersion="19"/>. A minSdkVersion of API Level 11 has been specified already
